### PR TITLE
Adding Rivals tab and replay history. 

### DIFF
--- a/patches/leaderboard.js
+++ b/patches/leaderboard.js
@@ -6,7 +6,6 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 
     const uiOffset = dict.uiSizes + "." + dict.gap
     const rawPlayerNames = dict.playerData + "." + dict.rawPlayerNames
-    const playerBalances = dict.playerData + "." + dict.playerBalances
     const playerTerritories = dict.playerData + "." + dict.playerTerritories
 
 	const { topBarHeight } = matchCode(`aAn = 0.000 * aAd; topBarHeight = Math.floor(0.45 * aAm + aAf);`)
@@ -127,7 +126,10 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 		a0A.fillStyle = aZ.kZ,
 		a0A.fillRect(0, a0F, a04, y9 - a0F);
 		if (__fx.leaderboardFilter.enabled) updateFilteredLb();
-		if (__fx.leaderboardFilter.showingRivals) __fx.leaderboardFilter.computeRivals();
+		if (__fx.leaderboardFilter.showingRivals && leaderboardHasChanged) {
+			__fx.leaderboardFilter.computeRivals();
+			leaderboardHasChanged = false;
+		}
 		var playerPos = (__fx.leaderboardFilter.enabled
 			? this.playerPos
 			: leaderboardPositionsById[game.playerId]
@@ -157,6 +159,7 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 		a0A.fillRect(0, y9 - b0.ur, a04, b0.ur),`)
             replaceRawCode("var hZ,eh=leaderboardPositionsById[game.playerId]<position+windowHeight-1?1:2;for(a0A.font=a07,aY.g0.textAlign(a0A,0),hZ=windowHeight-eh;0<=hZ;hZ--)a0a(leaderboardArray[hZ+position]),a0b(hZ,hZ+position,leaderboardArray[hZ+position]);for(aY.g0.textAlign(a0A,2),hZ=windowHeight-eh;0<=hZ;hZ--)a0a(leaderboardArray[hZ+position]),a0c(hZ,leaderboardArray[hZ+position]);",
                 `var hZ, eh = playerPos < position + windowHeight - 1 ? 1 : 2;
+		if (__fx.leaderboardFilter.showingRivals) eh = 1;
 
 		if (__fx.leaderboardFilter.showingRivals) {
 			var rivalsRestore = [];
@@ -165,10 +168,8 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 					var rivalsEntry = __fx.leaderboardFilter.rivalsData[rivalsRow + position];
 					if (rivalsEntry === undefined) break;
 					var repId = rivalsEntry.representativeId;
-					rivalsRestore.push([repId, ${rawPlayerNames}[repId], ${playerTerritories}[repId], ${playerBalances}[repId], ${cachedDisplayName}[repId]]);
-					${rawPlayerNames}[repId] = "[" + rivalsEntry.clan + "]";
+					rivalsRestore.push([repId, ${playerTerritories}[repId], ${cachedDisplayName}[repId]]);
 					${playerTerritories}[repId] = rivalsEntry.territory;
-					${playerBalances}[repId] = rivalsEntry.territory;
 					${cachedDisplayName}[repId] = "[" + rivalsEntry.clan + "]";
 				}
 				for (a0A.font = a07, aY.g0.textAlign(a0A, 0), hZ = windowHeight - eh; 0 <= hZ; hZ--) {
@@ -183,10 +184,8 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 				}
 			} finally {
 				rivalsRestore.forEach(function(entry) {
-					${rawPlayerNames}[entry[0]] = entry[1];
-					${playerTerritories}[entry[0]] = entry[2];
-					${playerBalances}[entry[0]] = entry[3];
-					${cachedDisplayName}[entry[0]] = entry[4];
+					${playerTerritories}[entry[0]] = entry[1];
+					${cachedDisplayName}[entry[0]] = entry[2];
 				});
 			}
 		} else if (__fx.leaderboardFilter.enabled) {
@@ -222,7 +221,10 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
             replaceRawCode("var a0p=a0q(fJ);return ag.tQ()&&-1!==a0P&&(a0P=-1,a0Y(),b3.d1=!0),b3.dY-a0Q<350&&a0T===a0p&&-1!==(a0p=(a0p=yr(-1,a0p,windowHeight))!==windowHeight&&vU(x,y)?a0p:-1)&&(x=leaderboardArray[a0p+position],a0p===windowHeight-1&&leaderboardPositionsById[game.playerId]>=position+windowHeight-1&&(x=game.playerId),",
                 `var a0p = a0q(fJ);
 		var isEmptySpace = false;
-		return ag.tQ() && -1 !== a0P && (a0P = -1, a0Y(), b3.d1 = !0), b3.dY - a0Q < 350 && a0T === a0p && -1 !== (a0p = (a0p = yr(-1, a0p, windowHeight)) !== windowHeight && vU(x, y) ? a0p : -1) && (x = (__fx.leaderboardFilter.enabled ? (updateFilteredLb(), leaderboardArray[__fx.leaderboardFilter.filteredLeaderboard[a0p + position] ?? (isEmptySpace = true, leaderboardPositionsById[game.playerId])]) : leaderboardArray[a0p + position]), a0p === windowHeight - 1 && (__fx.leaderboardFilter.enabled ? this.playerPos : leaderboardPositionsById[game.playerId]) >=
+		return ag.tQ() && -1 !== a0P && (a0P = -1, a0Y(), b3.d1 = !0), b3.dY - a0Q < 350 && a0T === a0p && -1 !== (a0p = (a0p = yr(-1, a0p, windowHeight)) !== windowHeight && vU(x, y) ? a0p : -1) && (x = (__fx.leaderboardFilter.showingRivals
+			? (isEmptySpace = __fx.leaderboardFilter.rivalsData[a0p + position] === undefined, __fx.leaderboardFilter.rivalsData[a0p + position]?.representativeId ?? game.playerId)
+			: __fx.leaderboardFilter.enabled ? (updateFilteredLb(), leaderboardArray[__fx.leaderboardFilter.filteredLeaderboard[a0p + position] ?? (isEmptySpace = true, leaderboardPositionsById[game.playerId])]) : leaderboardArray[a0p + position]),
+			a0p === windowHeight - 1 && !__fx.leaderboardFilter.showingRivals && (__fx.leaderboardFilter.enabled ? this.playerPos : leaderboardPositionsById[game.playerId]) >=
 			position + windowHeight - 1 && (x = game.playerId),`);
             // Get clan parsing function
             replaceRawCode(`this.uI=function(username){var uK,uJ=username.indexOf("[");return!(uJ<0)&&1<(uK=username.indexOf("]"))-uJ&&uK-uJ<=8?username.substring(uJ+1,uK).toUpperCase().trim():null},`,

--- a/patches/leaderboard.js
+++ b/patches/leaderboard.js
@@ -4,8 +4,10 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 
 	// Player list and leaderboard filter tabs
 
-	const uiOffset = dict.uiSizes + "." + dict.gap
-	const rawPlayerNames = dict.playerData + "." + dict.rawPlayerNames
+    const uiOffset = dict.uiSizes + "." + dict.gap
+    const rawPlayerNames = dict.playerData + "." + dict.rawPlayerNames
+    const playerBalances = dict.playerData + "." + dict.playerBalances
+    const playerTerritories = dict.playerData + "." + dict.playerTerritories
 
 	const { topBarHeight } = matchCode(`aAn = 0.000 * aAd; topBarHeight = Math.floor(0.45 * aAm + aAf);`)
 	const buttonBoundsCheck = `__fx.utils.isPointInRectangle(x, y, ${uiOffset} + 12, ${uiOffset} + 12, ${topBarHeight} - 22, ${topBarHeight} - 22)`
@@ -94,6 +96,12 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 	}
 
     waitForMinification(() => {
+        const { cachedDisplayNameProp } = matchCode(
+            `PD.cachedDisplayNameProp[i] = someObj1.someObj2.someFn(RPN[i], someFont, someWidth)`,
+            { dictionary: { PD: dict.playerData, RPN: rawPlayerNames } }
+        )
+        const cachedDisplayName = dict.playerData + "." + cachedDisplayNameProp
+
         // Draw player list button
         replaceOne(/(="";function (?<drawFunction>\w+)\(\){[^}]+?(?<canvas>\w+)\.fillRect\(0,(?<topBarHeight>\w+),\w+,1\),(?:\3\.fillRect\([^()]+\),)+\3\.font=\w+,(\w+\.\w+)\.textBaseline\(\3,1\),\5\.textAlign\(\3,1\),\3\.fillText\(\w+,Math\.floor\()(\w+)\/2\),(Math\.floor\(\w+\+\w+\/2\)\));/g,
             "$1($6 + $<topBarHeight> - 22) / 2), $7; __fx.playerList.drawButton($<canvas>, 12, 12, $<topBarHeight> - 22);")
@@ -119,14 +127,21 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 		a0A.fillStyle = aZ.kZ,
 		a0A.fillRect(0, a0F, a04, y9 - a0F);
 		if (__fx.leaderboardFilter.enabled) updateFilteredLb();
+		if (__fx.leaderboardFilter.showingRivals) __fx.leaderboardFilter.computeRivals();
 		var playerPos = (__fx.leaderboardFilter.enabled
 			? this.playerPos
 			: leaderboardPositionsById[game.playerId]
 		);
 		if (__fx.leaderboardFilter.hoveringOverTabs) a0P = -1;
 		if (__fx.leaderboardFilter.enabled && a0P >= __fx.leaderboardFilter.filteredLeaderboard.length) a0P = -1;
-		playerPos >= position && a0Z(playerPos - position, aZ.kw),
-		0 !== leaderboardPositionsById[game.playerId] && 0 === position && a0Z(0, aZ.lJ),
+		(__fx.leaderboardFilter.showingRivals
+			? (function() {
+				var ownClanIndex = __fx.leaderboardFilter.getOwnClanIndex();
+				if (ownClanIndex >= 0 && ownClanIndex >= position) a0Z(ownClanIndex - position, aZ.kw);
+			})()
+			: (playerPos >= position && a0Z(playerPos - position, aZ.kw),
+				0 !== leaderboardPositionsById[game.playerId] && 0 === position && a0Z(0, aZ.lJ))
+		),
 		-1 !== a0P && a0Z(a0P, aZ.kd),
 		a0A.fillStyle = aZ.kZ,
 		//console.log("drawing", a0P),
@@ -142,8 +157,39 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 		a0A.fillRect(0, y9 - b0.ur, a04, b0.ur),`)
             replaceRawCode("var hZ,eh=leaderboardPositionsById[game.playerId]<position+windowHeight-1?1:2;for(a0A.font=a07,aY.g0.textAlign(a0A,0),hZ=windowHeight-eh;0<=hZ;hZ--)a0a(leaderboardArray[hZ+position]),a0b(hZ,hZ+position,leaderboardArray[hZ+position]);for(aY.g0.textAlign(a0A,2),hZ=windowHeight-eh;0<=hZ;hZ--)a0a(leaderboardArray[hZ+position]),a0c(hZ,leaderboardArray[hZ+position]);",
                 `var hZ, eh = playerPos < position + windowHeight - 1 ? 1 : 2;
-		
-		if (__fx.leaderboardFilter.enabled) {
+
+		if (__fx.leaderboardFilter.showingRivals) {
+			var rivalsRestore = [];
+			try {
+				for (var rivalsRow = 0; rivalsRow < windowHeight; rivalsRow++) {
+					var rivalsEntry = __fx.leaderboardFilter.rivalsData[rivalsRow + position];
+					if (rivalsEntry === undefined) break;
+					var repId = rivalsEntry.representativeId;
+					rivalsRestore.push([repId, ${rawPlayerNames}[repId], ${playerTerritories}[repId], ${playerBalances}[repId], ${cachedDisplayName}[repId]]);
+					${rawPlayerNames}[repId] = "[" + rivalsEntry.clan + "]";
+					${playerTerritories}[repId] = rivalsEntry.territory;
+					${playerBalances}[repId] = rivalsEntry.territory;
+					${cachedDisplayName}[repId] = "[" + rivalsEntry.clan + "]";
+				}
+				for (a0A.font = a07, aY.g0.textAlign(a0A, 0), hZ = windowHeight - eh; 0 <= hZ; hZ--) {
+					const rivalsEntryLeft = __fx.leaderboardFilter.rivalsData[hZ + position];
+					if (rivalsEntryLeft !== undefined)
+						a0a(rivalsEntryLeft.representativeId), a0b(hZ, hZ + position, rivalsEntryLeft.representativeId);
+				}
+				for (aY.g0.textAlign(a0A, 2), hZ = windowHeight - eh; 0 <= hZ; hZ--) {
+					const rivalsEntryRight = __fx.leaderboardFilter.rivalsData[hZ + position];
+					if (rivalsEntryRight !== undefined)
+						a0a(rivalsEntryRight.representativeId), a0c(hZ, rivalsEntryRight.representativeId);
+				}
+			} finally {
+				rivalsRestore.forEach(function(entry) {
+					${rawPlayerNames}[entry[0]] = entry[1];
+					${playerTerritories}[entry[0]] = entry[2];
+					${playerBalances}[entry[0]] = entry[3];
+					${cachedDisplayName}[entry[0]] = entry[4];
+				});
+			}
+		} else if (__fx.leaderboardFilter.enabled) {
 			let result = __fx.leaderboardFilter.filteredLeaderboard;
 			if (position !== 0 && position >= result.length - windowHeight)
 				position = (result.length > windowHeight ? result.length : windowHeight) - windowHeight;
@@ -181,6 +227,11 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
             // Get clan parsing function
             replaceRawCode(`this.uI=function(username){var uK,uJ=username.indexOf("[");return!(uJ<0)&&1<(uK=username.indexOf("]"))-uJ&&uK-uJ<=8?username.substring(uJ+1,uK).toUpperCase().trim():null},`,
                 `this.uI=function(username){var uK,uJ=username.indexOf("[");return!(uJ<0)&&1<(uK=username.indexOf("]"))-uJ&&uK-uJ<=8?username.substring(uJ+1,uK).toUpperCase().trim():null}, __fx.leaderboardFilter.parseClanFromPlayerName = this.uI;`);
+			// no pinning player on leaderboard in rivals tab
+            replaceRawCode(
+                `2==gi&&(aBj(aE.et),bD.r2.textAlign(aBH,0),aBk(aBF-1,kF[aE.et],aE.et),bD.r2.textAlign(aBH,2),aBl(aBF-1,aE.et)),`,
+                `!__fx.leaderboardFilter.showingRivals&&2==gi&&(aBj(aE.et),bD.r2.textAlign(aBH,0),aBk(aBF-1,kF[aE.et],aE.et),bD.r2.textAlign(aBH,2),aBl(aBF-1,aE.et)),`
+            );
         }
     })
 })

--- a/patches/replayHistory.js
+++ b/patches/replayHistory.js
@@ -1,9 +1,11 @@
 import { definePatch } from "../modUtils.js"
 
-export default definePatch(({ insertCode }) => {
+export default definePatch(({ replaceRawCode }) => {
   // keep a rolling history of last 5 replays.
-  insertCode(
-    `this.a5h = bC.a5u.a0a(); /* here */`,
-    `__fx.replayHistory.save(this.a5h);`
+  // using replaceRawCode since minification removes a semi colon before the closing brace
+  // so it does not match with replaceCode or insertCode
+  replaceRawCode(
+    `this.a5h=bC.a5u.a0a()}else{this.a5h=bC.qM.a5t}b1.z.a5v();bt.clear();this.a18=0;bi.a5w();`,
+    `this.a5h=bC.a5u.a0a();__fx.replayHistory.save(this.a5h);}else{this.a5h=bC.qM.a5t}b1.z.a5v();bt.clear();this.a18=0;bi.a5w();`
   )
 })

--- a/patches/replayHistory.js
+++ b/patches/replayHistory.js
@@ -1,0 +1,9 @@
+import { definePatch } from "../modUtils.js"
+
+export default definePatch(({ insertCode }) => {
+  // keep a rolling history of last 5 replays.
+  insertCode(
+    `this.a5h = bC.a5u.a0a(); /* here */`,
+    `__fx.replayHistory.save(this.a5h);`
+  )
+})

--- a/src/clanFilters.js
+++ b/src/clanFilters.js
@@ -3,7 +3,7 @@ import { getVar } from "./gameInterface.js";
 export const leaderboardFilter = new (function() {
     //this.playersToInclude = [0,1,8,20,24,30,32,42,50,69,200,400,500,510,511]; // for testing
     this.playersToInclude = [];
-    this.tabLabels = ["ALL", "CLAN"];
+    this.tabLabels = ["ALL", "CLAN", "RIVALS"];
     // these get populated by the modified game code
     this.filteredLeaderboard = [];
     this.tabBarOffset = 0;
@@ -14,11 +14,42 @@ export const leaderboardFilter = new (function() {
     this.repaintLeaderboard = () => {};
     this.setUpdateFlag = () => {};
     this.parseClanFromPlayerName = () => { console.warn("parse function not set"); };
-    
+
     this.selectedTab = 0;
     this.tabHovering = -1;
     this.enabled = false;
     //this.enabled = true;
+    this.showingRivals = false;
+
+    this.rivalsData = [];
+    this.computeRivals = () => {
+        const rawNames = getVar("rawPlayerNames");
+        const playerTerritories = getVar("playerTerritories");
+        const gHumans = getVar("gHumans");
+        const totals = new Map();
+        for (let id = 0; id < gHumans; id++) {
+            const clan = this.parseClanFromPlayerName(rawNames[id]);
+            if (clan === null) continue;
+            const territory = playerTerritories[id] || 0;
+            const entry = totals.get(clan) || { territory: 0, representativeId: id, representativeTerritory: -1 };
+            entry.territory += territory;
+            if (territory > entry.representativeTerritory) {
+                entry.representativeTerritory = territory;
+                entry.representativeId = id;
+            }
+            totals.set(clan, entry);
+        }
+        this.rivalsData = Array.from(totals.entries())
+            .map(([clan, data]) => ({ clan, territory: data.territory, representativeId: data.representativeId }))
+            .sort((a, b) => b.territory - a.territory);
+    };
+    this.getOwnClanIndex = () => {
+        const playerId = getVar("playerId");
+        const ownClan = this.parseClanFromPlayerName(getVar("rawPlayerNames")[playerId]);
+        if (ownClan === null) return -1;
+        return this.rivalsData.findIndex((entry) => entry.clan === ownClan);
+    };
+
     this.drawTabs = function(canvas, totalWidth, verticalOffset, colorForSelectedTab) {
         canvas.textBaseline = "middle";
         canvas.textAlign = "center";
@@ -61,11 +92,17 @@ export const leaderboardFilter = new (function() {
         const tab = Math.floor(xRelative / (this.windowWidth / this.tabLabels.length));
         if (this.selectedTab !== tab) {
             this.selectedTab = tab;
+            this.showingRivals = false;
             if (this.selectedTab === 0) this.clearFilter();
             else if (this.selectedTab === 1) {
                 this.filterByOwnClan();
                 this.setUpdateFlag();
+            } else if (this.selectedTab === 2) {
+                this.enabled = false;
+                this.showingRivals = true;
+                this.computeRivals();
             }
+            this.scrollToTop();
             this.repaintLeaderboard();
         }
         return true;
@@ -83,6 +120,7 @@ export const leaderboardFilter = new (function() {
     this.clearFilter = () => { this.enabled = false; }
     this.reset = () => {
         this.enabled = false;
+        this.showingRivals = false;
         this.selectedTab = 0;
         clanFilter.refresh();
     }

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import { keybindFunctions, keybindHandler, mobileKeybinds } from "./keybinds.js"
 import customLobby from './customLobby.js';
 import { displayChangelog } from './changelog.js';
 import { reportError } from './debugging.js';
+import replayHistory from './replayHistory.js';
 
 window.__fx = window.__fx || {};
 const __fx = window.__fx;
@@ -39,5 +40,6 @@ __fx.hoveringTooltip = hoveringTooltip;
 __fx.clanFilter = clanFilter;
 __fx.wins = winCounter;
 __fx.customLobby = customLobby;
+__fx.replayHistory = replayHistory;
 
 console.log('Successfully loaded FX Client');

--- a/src/replayHistory.js
+++ b/src/replayHistory.js
@@ -1,0 +1,44 @@
+const STORAGE_KEY = "fx_replays";
+const MAX_REPLAYS = 5;
+
+function load() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch (error) {
+    console.warn("Failed to load replay history:", error);
+    return [];
+  }
+}
+
+function persist(replays) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(replays));
+  } catch (error) {
+    console.warn("Failed to save replay history:", error);
+  }
+}
+
+function save(replayData) {
+  if (!replayData) return;
+  const replays = load();
+  // avoid saving an exact duplicate if this fires twice for the same match
+  if (replays.length && replays[replays.length - 1].data === replayData) return;
+  replays.push({ data: replayData, timestamp: Date.now() });
+  while (replays.length > MAX_REPLAYS) replays.shift();
+  persist(replays);
+}
+
+function getAll() {
+  return load().slice().reverse(); // most recent first
+}
+
+function remove(timestamp) {
+  persist(load().filter((r) => r.timestamp !== timestamp));
+}
+
+function clear() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export default { save, getAll, remove, clear };

--- a/src/settings.js
+++ b/src/settings.js
@@ -36,6 +36,70 @@ __fx.makeMainMenuTransparent = false;
 /*var settingsGearIcon = document.createElement('img');
 settingsGearIcon.setAttribute('src', 'assets/geari_white.png');*/
 
+function ReplayHistoryList(container) {
+  const title = document.createElement("p");
+  title.innerHTML = "<b>Saved Replays</b> (auto-saves your last 5 games)";
+  container.append(title);
+
+  const list = document.createElement("div");
+  container.append(list);
+
+  function formatTime(timestamp) {
+    const minutes = Math.floor((Date.now() - timestamp) / 60000);
+    if (minutes < 1) return "just now";
+    if (minutes < 60) return minutes + "m ago";
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return hours + "h ago";
+    return Math.floor(hours / 24) + "d ago";
+  }
+
+  function render() {
+    list.innerHTML = "";
+    if (!__fx.replayHistory) return; // not initialized yet
+    const replays = __fx.replayHistory.getAll();
+    if (!replays.length) {
+      const empty = document.createElement("small");
+      empty.innerText = "No replays saved yet. Finish a game and it'll show up here.";
+      list.append(empty);
+      return;
+    }
+    replays.forEach((replay) => {
+      const row = document.createElement("div");
+      row.style.display = "flex";
+      row.style.alignItems = "center";
+      row.style.gap = "6px";
+      row.style.marginBottom = "4px";
+
+      const label = document.createElement("small");
+      label.innerText = formatTime(replay.timestamp);
+      label.style.flex = "1";
+
+      const copyBtn = document.createElement("button");
+      copyBtn.type = "button";
+      copyBtn.innerText = "Copy";
+      copyBtn.addEventListener("click", () => {
+        navigator.clipboard.writeText(replay.data).then(() => {
+          copyBtn.innerText = "Copied!";
+          setTimeout(() => (copyBtn.innerText = "Copy"), 1500);
+        }).catch(() => alert("Could not copy automatically \u2014 select the text manually."));
+      });
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.type = "button";
+      deleteBtn.innerText = "Delete";
+      deleteBtn.addEventListener("click", () => {
+        __fx.replayHistory.remove(replay.timestamp);
+        render();
+      });
+
+      row.append(label, copyBtn, deleteBtn);
+      list.append(row);
+    });
+  }
+
+  this.update = render;
+}
+
 const settingsManager = new (function () {
   const settingsStructure = [
     {
@@ -128,6 +192,7 @@ const settingsManager = new (function () {
       for: "keybindButtons", type: "checkbox",
       label: "Keybind buttons", note: "Show keybind buttons above the troop selector (max 6)"
     },
+    ReplayHistoryList,
     function Footer(container) {
       const versionInfo = document.createElement("p");
       versionInfo.innerText = `FX Client v${versionData.version}`;

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
-    "version": "0.6.20",
-    "lastUpdated": "May 19",
+    "version": "0.6.21",
+    "lastUpdated": "July 21",
     "changes": [
-        "The current tick number is now shown in the top bar near the balance. This can be disabled in the settings."
+        "New rivals tab in the leaderboard to show all clans sorted by cumulative land size and a feature that saves your last 5 replays."
     ],
     "isSignificant": true
 }


### PR DESCRIPTION
Rivals tab
This was suggested in the Discord and seemed like a useful addition for helping clans decide to peace out or not and get the win rather than guessing.

Replay history
Added replay history to prevent accidentally losing access to previous replays. Previously refreshing the page or joining another game would overwrite the current replay making it impossible to get again unless saved by you or someone else.

Both features have been tested by me in-game and are working as expected and everything else in the game still works as intended.

<img width="407" height="434" alt="Screenshot 2026-07-21 124413" src="https://github.com/user-attachments/assets/dc48f5bb-10fe-4b7b-aabf-0739231c1bb4" />
<img width="1730" height="314" alt="Screenshot 2026-07-21 124519" src="https://github.com/user-attachments/assets/a9242b60-b1c7-4e8e-8277-c7a3257f214e" />