### PR TITLE
Fix endless scrolling and player underline effect in rivals tab

### DIFF
--- a/patches/leaderboard.js
+++ b/patches/leaderboard.js
@@ -101,6 +101,13 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
         )
         const cachedDisplayName = dict.playerData + "." + cachedDisplayNameProp
 
+        // capture the property controlling player state (for fixing underscore on clans in rivals tab)
+        const { playerStateProp } = matchCode(
+            `someCanvas.fillText(CDN[i], someX, someY), 0 !== PD.playerStateProp[i] && (someCanvas.font = someFont)`,
+            { dictionary: { PD: dict.playerData, CDN: cachedDisplayName } }
+        )
+        const playerState = dict.playerData + "." + playerStateProp
+
         // Draw player list button
         replaceOne(/(="";function (?<drawFunction>\w+)\(\){[^}]+?(?<canvas>\w+)\.fillRect\(0,(?<topBarHeight>\w+),\w+,1\),(?:\3\.fillRect\([^()]+\),)+\3\.font=\w+,(\w+\.\w+)\.textBaseline\(\3,1\),\5\.textAlign\(\3,1\),\3\.fillText\(\w+,Math\.floor\()(\w+)\/2\),(Math\.floor\(\w+\+\w+\/2\)\));/g,
             "$1($6 + $<topBarHeight> - 22) / 2), $7; __fx.playerList.drawButton($<canvas>, 12, 12, $<topBarHeight> - 22);")
@@ -162,15 +169,19 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 		if (__fx.leaderboardFilter.showingRivals) eh = 1;
 
 		if (__fx.leaderboardFilter.showingRivals) {
+			let rivalsCount = __fx.leaderboardFilter.rivalsData.length;
+			if (position !== 0 && position >= rivalsCount - windowHeight)
+				position = (rivalsCount > windowHeight ? rivalsCount : windowHeight) - windowHeight;
 			var rivalsRestore = [];
 			try {
 				for (var rivalsRow = 0; rivalsRow < windowHeight; rivalsRow++) {
 					var rivalsEntry = __fx.leaderboardFilter.rivalsData[rivalsRow + position];
 					if (rivalsEntry === undefined) break;
 					var repId = rivalsEntry.representativeId;
-					rivalsRestore.push([repId, ${playerTerritories}[repId], ${cachedDisplayName}[repId]]);
+					rivalsRestore.push([repId, ${playerTerritories}[repId], ${cachedDisplayName}[repId], ${playerState}[repId]]);
 					${playerTerritories}[repId] = rivalsEntry.territory;
 					${cachedDisplayName}[repId] = "[" + rivalsEntry.clan + "]";
+					${playerState}[repId] = 0;
 				}
 				for (a0A.font = a07, aY.g0.textAlign(a0A, 0), hZ = windowHeight - eh; 0 <= hZ; hZ--) {
 					const rivalsEntryLeft = __fx.leaderboardFilter.rivalsData[hZ + position];
@@ -186,6 +197,7 @@ export default definePatch(({ safeDictionary: dict, modifyCode, waitForMinificat
 				rivalsRestore.forEach(function(entry) {
 					${playerTerritories}[entry[0]] = entry[1];
 					${cachedDisplayName}[entry[0]] = entry[2];
+					${playerState}[entry[0]] = entry[3];
 				});
 			}
 		} else if (__fx.leaderboardFilter.enabled) {

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
-    "version": "0.6.21",
-    "lastUpdated": "July 21",
+    "version": "0.6.22",
+    "lastUpdated": "July 22",
     "changes": [
-        "New rivals tab in the leaderboard to show all clans sorted by cumulative land size + a feature that saves your last 5 replays. (Merged PR #22 by QZxV4)"
+        "Fix endless scrolling and player underline effect in rivals tab (Merged PR #23 by QZxV4)"
     ],
-    "isSignificant": true
+    "isSignificant": false
 }


### PR DESCRIPTION
fixes endless scrolling past the end of the rivals list.
fixes the underscore effect meant for players who have left the game being applied to clans in the rivals tab