### PR TITLE
More colors in IP Highlighting and implement nicknames for following list

### DIFF
--- a/patches/followedAccounts.js
+++ b/patches/followedAccounts.js
@@ -1,0 +1,12 @@
+import { definePatch } from "../modUtils.js"
+
+export default definePatch(({ replaceCode }) => {
+
+    replaceCode(`this.get = function () { return accountNames; };
+        this.getListData = function () { return { aj: accountNames, value: 0 }; };
+        this.isFollowed = function (accountName) { return utils.array.has(accountNames, accountName); };`,
+        `this.get = function () { return accountNames; };
+        __fx.followedAccounts.setSource(this.get);
+        this.getListData = function () { return { aj: __fx.followedAccounts.decorate(accountNames), value: 0 }; };
+        this.isFollowed = function (accountName) { return utils.array.has(accountNames, accountName); };`)
+})

--- a/src/followedAccounts.js
+++ b/src/followedAccounts.js
@@ -1,0 +1,114 @@
+import { getSettings } from "./settings.js";
+import WindowManager from "./windowManager.js";
+
+const NICKNAME_SEPARATOR = " - ";
+const NICKNAME_MAX_LENGTH = 20;
+const WINDOW_NAME = "followedAccountNicknames";
+const SETTINGS_WINDOW_NAME = "settings";
+
+let source = () => [];
+let editedNicknames = {};
+
+function setSource(accountNameGetter) {
+  if (typeof accountNameGetter === "function") source = accountNameGetter;
+}
+
+function getAccounts() {
+  const accountNames = source();
+  return Array.isArray(accountNames) ? accountNames.slice() : [];
+}
+
+function cleanUp(nicknames) {
+  const cleaned = {};
+  if (nicknames === null || typeof nicknames !== "object") return cleaned;
+  Object.keys(nicknames).forEach((accountName) => {
+    const nickname = typeof nicknames[accountName] === "string"
+      ? nicknames[accountName].trim().slice(0, NICKNAME_MAX_LENGTH) : "";
+    if (nickname) cleaned[accountName] = nickname;
+  });
+  return cleaned;
+}
+
+function getNickname(accountName) {
+  const nicknames = getSettings().followedAccountNicknames;
+  const nickname = nicknames === null || typeof nicknames !== "object" ? "" : nicknames[accountName];
+  return typeof nickname === "string" ? nickname.trim() : "";
+}
+
+function label(accountName) {
+  const nickname = getNickname(accountName);
+  return nickname ? accountName + NICKNAME_SEPARATOR + nickname : accountName;
+}
+
+function decorate(accountNames) {
+  if (!Array.isArray(accountNames)) return accountNames;
+  return accountNames.map((accountName) => label(accountName));
+}
+
+const nicknamesWindow = WindowManager.create({
+  name: WINDOW_NAME,
+  closeWithButton: true,
+  modal: true,
+  beforeOpen: function () {
+    WindowManager.setWindowVisible(SETTINGS_WINDOW_NAME, false);
+    render();
+  },
+  onClose: function () {
+    if (WindowManager.isWindowOpen(SETTINGS_WINDOW_NAME)) WindowManager.setWindowVisible(SETTINGS_WINDOW_NAME, true);
+  }
+});
+const windowTitle = document.createElement("h1");
+windowTitle.innerText = "Followed Account Nicknames";
+const windowNote = document.createElement("small");
+windowNote.innerText =
+  "Nicknames are shown next to the account name in the \"Followed Accounts\" list. Close this menu and click \"Save Settings\" to apply.";
+const rows = document.createElement("div");
+nicknamesWindow.append(windowTitle, windowNote, document.createElement("br"), rows);
+
+function render() {
+  rows.innerHTML = "";
+  const accountNames = getAccounts();
+  if (!accountNames.length) {
+    const empty = document.createElement("small");
+    empty.innerText = "You aren't following any accounts yet.";
+    rows.append(empty);
+    return;
+  }
+  accountNames.forEach((accountName) => {
+    const row = document.createElement("div");
+    row.className = "nickname-row";
+    const name = document.createElement("span");
+    name.className = "nickname-account";
+    name.textContent = accountName;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.maxLength = NICKNAME_MAX_LENGTH;
+    input.placeholder = "Nickname";
+    input.value = editedNicknames[accountName] || "";
+    input.addEventListener("input", () => editedNicknames[accountName] = input.value);
+    row.append(name, input);
+    rows.append(row);
+  });
+}
+
+export function FollowedAccountNicknames(container) {
+  const title = document.createElement("p");
+  const heading = document.createElement("b");
+  heading.innerText = "Followed account nicknames";
+  title.append(heading);
+  const note = document.createElement("small");
+  note.innerText = "Label the accounts you follow with your own names, so the \"Followed Accounts\" list is easier to read.";
+  const openButton = document.createElement("button");
+  openButton.innerText = "Edit nicknames";
+  openButton.addEventListener("click", () => WindowManager.openWindow(WINDOW_NAME));
+  container.append(title, note, document.createElement("br"), openButton);
+
+  this.update = function (currentSettings) {
+    editedNicknames = cleanUp(currentSettings.followedAccountNicknames);
+  };
+  this.save = function (targetSettings) {
+    targetSettings.followedAccountNicknames = cleanUp(editedNicknames);
+  };
+}
+
+export default { setSource, decorate, label, getNickname };

--- a/src/gameScriptUtils.js
+++ b/src/gameScriptUtils.js
@@ -24,16 +24,26 @@ function textStyleBasedOnDensity(playerID) {
 }
 // specific color pallete so two ips dont have a similar looking color
 const duplicateIpColorPalette = [
-    "hsla(0, 85%, 50%, 0.5)",   // red
-    "hsla(210, 85%, 55%, 0.5)", // blue
-    "hsla(130, 70%, 45%, 0.5)", // green
-    "hsla(45, 90%, 55%, 0.5)",  // amber
-    "hsla(280, 75%, 60%, 0.5)", // purple
-    "hsla(185, 80%, 50%, 0.5)", // cyan
-    "hsla(320, 80%, 60%, 0.5)", // pink
-    "hsla(25, 85%, 50%, 0.5)",  // orange
-    "hsla(160, 60%, 40%, 0.5)", // teal
-    "hsla(255, 60%, 65%, 0.5)", // indigo
+    "hsla(0, 85%, 50%, 0.5)",
+    "hsla(18, 85%, 52%, 0.5)",
+    "hsla(36, 90%, 52%, 0.5)",
+    "hsla(50, 90%, 48%, 0.5)",
+    "hsla(72, 70%, 40%, 0.5)",
+    "hsla(95, 65%, 40%, 0.5)",
+    "hsla(130, 70%, 45%, 0.5)",
+    "hsla(150, 65%, 40%, 0.5)",
+    "hsla(165, 70%, 38%, 0.5)",
+    "hsla(185, 80%, 48%, 0.5)",
+    "hsla(200, 85%, 50%, 0.5)",
+    "hsla(215, 85%, 55%, 0.5)",
+    "hsla(235, 75%, 60%, 0.5)",
+    "hsla(255, 60%, 62%, 0.5)",
+    "hsla(270, 70%, 60%, 0.5)",
+    "hsla(285, 75%, 58%, 0.5)",
+    "hsla(300, 75%, 55%, 0.5)",
+    "hsla(315, 80%, 58%, 0.5)",
+    "hsla(330, 80%, 58%, 0.5)",
+    "hsla(345, 80%, 52%, 0.5)",
 ];
 
 function hashInt(n) {
@@ -46,28 +56,51 @@ function hashInt(n) {
 
 let cachedTeams = null;
 let cachedTeamsKey = null;
-let cachedIpCounts = null;
+let cachedIpColors = null;
+const assignedColorIndexes = new Map();
 
-function getIpCounts(teams, ipField) {
+function getIpColors(teams, ipField) {
     const key = ipField + "|" + teams.map(team => team.length).join(",");
-    if (cachedTeams === teams && cachedTeamsKey === key) return cachedIpCounts;
+    if (cachedTeams === teams && cachedTeamsKey === key) return cachedIpColors;
+
     const counts = new Map();
     teams.forEach(team => team.forEach(entry => {
         const ip = entry[ipField];
         if (ip === undefined) return;
         counts.set(ip, (counts.get(ip) || 0) + 1);
     }));
+
+    const paletteLength = duplicateIpColorPalette.length;
+    const duplicates = [...counts.keys()].filter(ip => counts.get(ip) >= 2).sort();
+    const duplicateSet = new Set(duplicates);
+    assignedColorIndexes.forEach((_, ip) => {
+        if (!duplicateSet.has(ip)) assignedColorIndexes.delete(ip);
+    });
+
+    const taken = new Set(assignedColorIndexes.values());
+    duplicates.forEach(ip => {
+        if (assignedColorIndexes.has(ip)) return;
+        let index = hashInt(ip) % paletteLength;
+        if (taken.size < paletteLength) {
+            while (taken.has(index)) index = (index + 1) % paletteLength;
+            taken.add(index);
+        }
+        assignedColorIndexes.set(ip, index);
+    });
+
+    const colors = new Map();
+    duplicates.forEach(ip => colors.set(ip, duplicateIpColorPalette[assignedColorIndexes.get(ip)]));
+
     cachedTeams = teams;
     cachedTeamsKey = key;
-    cachedIpCounts = counts;
-    return counts;
+    cachedIpColors = colors;
+    return colors;
 }
 
 function getDuplicateIpHighlightColor(player, teams, ipField) {
     const ip = player[ipField];
     if (ip === undefined) return null;
-    if ((getIpCounts(teams, ipField).get(ip) || 0) < 2) return null;
-    return duplicateIpColorPalette[hashInt(ip) % duplicateIpColorPalette.length];
+    return getIpColors(teams, ipField).get(ip) || null;
 }
 
 export default { getMaxTroops, getDensity, isPointInRectangle, fillTextMultiline, textStyleBasedOnDensity, getDuplicateIpHighlightColor }

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import replay from './replay.js';
 import lobbyReminders from './lobbyReminders.js';
 import pingFilter from './pingFilter.js';
 import nameFilter from './nameFilter.js';
+import followedAccounts from './followedAccounts.js';
 
 window.__fx = window.__fx || {};
 const __fx = window.__fx;
@@ -49,5 +50,6 @@ __fx.replay = replay;
 __fx.lobbyReminders = lobbyReminders;
 __fx.pingFilter = pingFilter;
 __fx.nameFilter = nameFilter;
+__fx.followedAccounts = followedAccounts;
 
 console.log('Successfully loaded FX Client');

--- a/src/settings.js
+++ b/src/settings.js
@@ -5,6 +5,7 @@ import versionData from '../version.json';
 import { displayChangelog } from './changelog.js';
 import replayHistory from './replayHistory.js'
 import { LobbyReminderRulesInput } from './lobbyReminderRulesInput.js';
+import { FollowedAccountNicknames } from './followedAccounts.js';
 
 window.__fx = window.__fx || {};
 const __fx = window.__fx;
@@ -42,7 +43,8 @@ var settings = {
   mutePingClan: false,
   mutePingLanguage: false,
   mutePingDirect: false,
-  hideInappropriateNames: false
+  hideInappropriateNames: false,
+  followedAccountNicknames: {}
 };
 __fx.settings = settings;
 const discontinuedSettings = ["hideAllLinks", "fontName"];
@@ -537,6 +539,7 @@ const settingsManager = new (function () {
       label: "Inappropriate name hider",
       note: "Replaces player names that contain common offensive or inappropriate words with \"Hidden Name\".",
     },
+    FollowedAccountNicknames,
     ReplayHistoryList,
     function Footer(container) {
       const versionInfo = document.createElement("p");

--- a/src/windowManager.js
+++ b/src/windowManager.js
@@ -39,7 +39,14 @@ function closeWindow(windowName) {
   windows[windowName].element.style.display = "none";
   if (windows[windowName].onClose !== undefined) windows[windowName].onClose();
 }
+function isWindowOpen(windowName) {
+  return windows[windowName].isOpen === true;
+}
+function setWindowVisible(windowName, visible) {
+  windows[windowName].element.style.display = visible ? null : "none";
+}
 function closeAll() {
+  if (Object.values(windows).some((windowObj) => windowObj.modal === true && windowObj.isOpen === true)) return;
   Object.values(windows).forEach(function (windowObj) {
     if (windowObj.closable !== false) closeWindow(windowObj.name);
   });
@@ -66,4 +73,4 @@ document.addEventListener("keydown", (event) => {
   if (event.key === "Escape") closeAll();
 });
 
-export default { create, add, openWindow, closeWindow, closeAll };
+export default { create, add, openWindow, closeWindow, closeAll, isWindowOpen, setWindowVisible };

--- a/static/main.css
+++ b/static/main.css
@@ -83,6 +83,17 @@
 	flex: 0 0 auto;
 }
 
+.nickname-row {
+	display    : flex;
+	gap        : 6px;
+	align-items: center;
+}
+.nickname-row .nickname-account {
+	flex          : 1;
+	min-width     : 0;
+	overflow-wrap : anywhere;
+}
+
 .flex {
 	display: flex;
 }

--- a/version.json
+++ b/version.json
@@ -1,8 +1,10 @@
 {
-    "version": "0.6.27",
-    "lastUpdated": "August 7",
+    "version": "0.6.28",
+    "lastUpdated": "August 11",
     "changes": [
-        "Fix bugs from the previous update (Merged PR #28 by QZxV4)"
+        "Merged PR #29 by QZxV4, implementing the following changes:",
+        "The IP Highlighting feature now has more colors, lowering the chance of the same color appearing for different IPs (no effect on different IP but same hash of course), so now it's easier to distinguish groups of shared IPs wihout having to hover over them.",
+        "You can now set nicknames on each entry in the list of accounts you follow, making it easier to figure out who each player is. The feature can be enabled and configured in the FX Client settings."
     ],
     "isSignificant": true
 }


### PR DESCRIPTION
The IP Highlighting now has more colors and reduces the amount of the same color appearing for different IPs. (no effect on different ip but same hash of course). So that its more easy to tell groups of shared IPs rather than having to hover over them.

Added the nickname feature that was suggested in FX and in main server for the following list so that its easier for players to figure out who each person on their following list is. Uses a seperate menu accessible from inside the settings so that the settings menu doesn't look to cluttered. 

<img width="342" height="363" alt="Screenshot 2026-08-10 155153" src="https://github.com/user-attachments/assets/30b26a3f-2b46-4b30-9050-2c777cd81e5c" />
<img width="1696" height="351" alt="Screenshot 2026-08-10 155209" src="https://github.com/user-attachments/assets/56ec8d51-95e2-4034-87fc-3637a5d8bd03" />

